### PR TITLE
feat: add supply chain analyzer

### DIFF
--- a/src/constants/filters.js
+++ b/src/constants/filters.js
@@ -20,7 +20,7 @@ FOOD_OPTIONS.unshift({
 export const SCOPE_OPTIONS = [
   { value: 'global', label: 'Global' },
   { value: 'country', label: 'Country' },
-  // { value: 'supply_chain', label: 'Supply Chain' }
+  { value: 'supply_chain', label: 'Supply Chain' }
 ];
 
 export const CATEGORIES = {


### PR DESCRIPTION
This pull request includes a small change to the `src/constants/filters.js` file. The change re-enables the 'Supply Chain' option in the `SCOPE_OPTIONS` array.

* [`src/constants/filters.js`](diffhunk://#diff-0f037c8f1011514f7c8f9f210f90c74acf00830e19ace7f76cb21a0e64bdef29L23-R23): Uncommented the 'Supply Chain' option in the `SCOPE_OPTIONS` array.