### PR TITLE
[AQ-224] timeframe changes independently from water risk selection an…

### DIFF
--- a/src/components/filters/component.js
+++ b/src/components/filters/component.js
@@ -123,7 +123,7 @@ class Filters extends PureComponent {
       }
     } = this.props;
 
-    if (selected && selected.value === 'baseline') this.updateFilters('absolute', 'type');
+    // if (selected && selected.value === 'baseline') this.updateFilters('absolute', 'type');
     if (selected) {
       const { value } = selected;
       this.updateFilters(value, 'year');
@@ -131,15 +131,11 @@ class Filters extends PureComponent {
       if (currentYear === 'baseline' && value !== 'baseline') {
         if (EQUIVALENCE_WATER_INDICATORS[indicator]) {
           this.updateFilters(EQUIVALENCE_WATER_INDICATORS[indicator], 'indicator');
-        } else {
-          this.updateFilters(DEFAULT_PROJECTED_WATER_INDICATOR, 'indicator');
         }
       }
       if (currentYear !== 'baseline' && value === 'baseline') {
         if (EQUIVALENCE_WATER_INDICATORS[indicator]) {
           this.updateFilters(EQUIVALENCE_WATER_INDICATORS[indicator], 'indicator');
-        } else {
-          this.updateFilters(DEFAULT_BASELINE_WATER_INDICATOR, 'indicator');
         }
       }
     }
@@ -148,12 +144,7 @@ class Filters extends PureComponent {
   updateFilters(value, field) {
     const { setFilters } = this.props;
     const newFilter = {
-      [field]: value,
-      ...(field === 'scope' && value === 'global') && {
-        iso: null,
-        country: null,
-        countryName: null
-      }
+      [field]: value
     };
 
     setFilters(newFilter);

--- a/src/constants/water-indicators.js
+++ b/src/constants/water-indicators.js
@@ -665,6 +665,7 @@ export const PROJECTED_WATER_INDICATORS_IDS = [...PROJECTED_WATER_INDICATORS_ABS
 export const EQUIVALENCE_WATER_INDICATORS = {
   // water stress - baseline / projected
   '': IDS.bws.projectedAbsolute,
+  [IDS.bws.baseline]: IDS.bws.projectedAbsolute,
   [IDS.bws.projectedAbsolute]: IDS.bws.baseline,
   // seasonal variability - baseline / projected
   [IDS.sev.baseline]: IDS.sev.projectedAbsolute,


### PR DESCRIPTION
This pull request includes several updates to the `Filters` component and water indicators constants to improve the filtering logic and handle equivalence water indicators more effectively. The most important changes are summarized below:

### Updates to `Filters` component:

* Commented out the line that updates filters to 'absolute' when the selected value is 'baseline'. (`src/components/filters/component.js`, [src/components/filters/component.jsL126-L142](diffhunk://#diff-bf6c21820ec134e0ddde4caf463f2b46fa016eb2ca4f1d179ee164c1b5ed89d0L126-L142))
* Removed redundant code that set default water indicators when the current year was 'baseline' or not 'baseline'. (`src/components/filters/component.js`, [src/components/filters/component.jsL126-L142](diffhunk://#diff-bf6c21820ec134e0ddde4caf463f2b46fa016eb2ca4f1d179ee164c1b5ed89d0L126-L142))
* Simplified the `updateFilters` method by removing the conditional logic for setting additional fields when the scope is 'global'. (`src/components/filters/component.js`, [src/components/filters/component.jsL151-R147](diffhunk://#diff-bf6c21820ec134e0ddde4caf463f2b46fa016eb2ca4f1d179ee164c1b5ed89d0L151-R147))

### Updates to water indicators constants:

* Added a new mapping in `EQUIVALENCE_WATER_INDICATORS` to handle the equivalence between baseline and projected absolute water stress indicators. (`src/constants/water-indicators.js`, [src/constants/water-indicators.jsR668](diffhunk://#diff-994039f922a29766bfda42116b7a38ee153861287f0cfa73f25168593ae9c484R668))