### PR TITLE
AQ-303 food replace ifpri 3 4 url in widgets legends and info buttons

### DIFF
--- a/requests/updateMetadata/foodDemand.http
+++ b/requests/updateMetadata/foodDemand.http
@@ -21,7 +21,7 @@ Authorization: {{token}}
   "info": {
     "sources": [
       {
-        "source-url": "https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/",
+        "source-url": "https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8",
         "source-name": "IFPRI IMPACT Model 3.4"
       },
       {

--- a/requests/updateMetadata/foodProduction.http
+++ b/requests/updateMetadata/foodProduction.http
@@ -21,7 +21,7 @@ Authorization: {{token}}
   "info": {
     "sources": [
       {
-        "source-url": "https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/",
+        "source-url": "https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8",
         "source-name": "IFPRI IMPACT Model 3.4"
       },
       {

--- a/requests/updateMetadata/kCalPerCapita.http
+++ b/requests/updateMetadata/kCalPerCapita.http
@@ -21,7 +21,7 @@ Authorization: {{token}}
   "info": {
     "sources": [
       {
-        "source-url": "https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/",
+        "source-url": "https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8",
         "source-name": "IFPRI IMPACT Model 3.4"
       },
       {

--- a/requests/updateMetadata/netTrade.http
+++ b/requests/updateMetadata/netTrade.http
@@ -21,7 +21,7 @@ Authorization: {{token}}
   "info": {
     "sources": [
       {
-        "source-url": "https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/",
+        "source-url": "https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8",
         "source-name": "IFPRI IMPACT Model 3.4"
       },
       {

--- a/requests/updateMetadata/popAtRiskOfHunger.http
+++ b/requests/updateMetadata/popAtRiskOfHunger.http
@@ -21,7 +21,7 @@ Authorization: {{token}}
   "info": {
     "sources": [
       {
-        "source-url": "https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/",
+        "source-url": "https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8",
         "source-name": "IFPRI IMPACT Model 3.4"
       },
       {

--- a/src/constants/definitions.js
+++ b/src/constants/definitions.js
@@ -113,7 +113,7 @@ export const APP_DEFINITIONS = {
         <li>Kilocalories per person represents the availability of calories per person.</li>
         <li>Share of population at risk of hunger represents the percentage of the population at risk of suffering from malnourishment.</li>
       </ul>`,
-    source: '<a href="https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/" target="_blank" rel="noopener noreferrer">IFPRI IMPACT Model 3.4</a> & <a href="https://doi.org/10.1016/j.gfs.2024.100755" target="_blank" rel="noopener noreferrer">Research paper</a>'
+    source: '<a href="https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8" target="_blank" rel="noopener noreferrer">IFPRI IMPACT Model 3.4</a> & <a href="https://doi.org/10.1016/j.gfs.2024.100755" target="_blank" rel="noopener noreferrer">Research paper</a>'
   },
   timeframe: {
     title: 'Timeframe',
@@ -122,7 +122,7 @@ export const APP_DEFINITIONS = {
       <p>Baseline reflects different years depending on the dataset. Crop area baseline data are from 2020, food security baseline data are from 2020, and water risk baseline data are based on 1979 to 2019. Future projections are not available if water risk indicators without future projections have been selected (i.e., interannual variability, drought risk, groundwater table decline, and coastal eutrophication potential).</p>
       <p>In future years, select "absolute value" to see the projected water risk in the selected year. Future projections are based on business-as-usual climate change and water demand projections.</p>
     `,
-    source: 'For baseline and future water risk indicators & methodology, see <a href="https://mapspam.info/data/" target="_blank" rel="noopener noreferrer">Aqueduct 4.0</a>. For Food Security projections see <a href="https://ebrary.ifpri.org/digital/collection/p15738coll2/id/129825/" target="_blank" rel="noopener noreferrer">IFPRI IMPACT Model 3.4</a>.'
+    source: 'For baseline and future water risk indicators & methodology, see <a href="https://mapspam.info/data/" target="_blank" rel="noopener noreferrer">Aqueduct 4.0</a>. For Food Security projections see <a href="https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8" target="_blank" rel="noopener noreferrer">IFPRI IMPACT Model 3.4</a>.'
   },
   area: {
     title: 'Area',


### PR DESCRIPTION

This pull request updates the source URL for the IFPRI IMPACT Model 3.4 throughout the codebase and metadata files, replacing the previous `ebrary.ifpri.org` link with a new link to `cgspace.cgiar.org`. This ensures that all references to the IFPRI IMPACT Model 3.4 point to a more current and reliable source.

**Reference URL updates:**

* Updated the `source-url` for IFPRI IMPACT Model 3.4 in the metadata files: `foodDemand.http`, `foodProduction.http`, `kCalPerCapita.http`, `netTrade.http`, and `popAtRiskOfHunger.http` to use `https://cgspace.cgiar.org/items/7b88a53b-5f32-4405-a7d5-a0e25677b9a8` instead of the previous `ebrary.ifpri.org` link. [[1]](diffhunk://#diff-2e99165b4b8c418507aa944952151ccef38a055759d2959170341e814c42436cL24-R24) [[2]](diffhunk://#diff-8efb86470e5865a5d2c24078a0f1d59cc66f1013adf000e3bfac3f180d3f02e9L24-R24) [[3]](diffhunk://#diff-d708952a18b6741d62aaf02bdca56297c08c096233b782e2c2b2c8170f7271ecL24-R24) [[4]](diffhunk://#diff-3b0b612ef595807aaa267182d2db850f4d3d5e77f8bd00eb7280725ae3dd2a2dL24-R24) [[5]](diffhunk://#diff-c7d675fe8ce192bef2842dfeeee764260c2f9a7511c958cd7b750bff19c548e0L24-R24)

* Updated the IFPRI IMPACT Model 3.4 source link in the `APP_DEFINITIONS` object in `src/constants/definitions.js` to use the new `cgspace.cgiar.org` URL in both the main source and the food security projections source descriptions. [[1]](diffhunk://#diff-cb4ccd5f5eb384a69ceecbdf1495797e05ecc7eafb3804c68981685fa7beca5eL116-R116) [[2]](diffhunk://#diff-cb4ccd5f5eb384a69ceecbdf1495797e05ecc7eafb3804c68981685fa7beca5eL125-R125)